### PR TITLE
Set .NET framework version to 4.5.2

### DIFF
--- a/STL_Adapter/STL_Adapter.csproj
+++ b/STL_Adapter/STL_Adapter.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.Adapter.STL</RootNamespace>
     <AssemblyName>STL_Adapter</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />

--- a/STL_Engine/STL_Engine.csproj
+++ b/STL_Engine/STL_Engine.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>BH.Engine.Adapters.STL</RootNamespace>
     <AssemblyName>STL_Engine</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
     <TargetFrameworkProfile />


### PR DESCRIPTION
### Issues addressed by this PR
Set the .NET framework version of the projects in this toolkit to 4.5.2

### Test files
This PR will be reviewed by making sure that an installer can be produced from it. 