### PR TITLE
Fix for missing configuration of AdapterId

### DIFF
--- a/STL_Adapter/STL_Adapter.cs
+++ b/STL_Adapter/STL_Adapter.cs
@@ -52,6 +52,7 @@ namespace BH.Adapter.STL
             }
 
             m_AdapterSettings.DefaultPushType = oM.Adapter.PushType.CreateOnly;
+            m_AdapterSettings.UseAdapterId = false;
             m_stlSettings = stlSettings;
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

Adds a line that sets the adapter ID to be false. 

### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #52 

<!-- Add short description of what has been fixed -->


### Test files
<!-- Link to test files to validate the proposed changes -->
Tested using the most recent STL Toolkit testing procedure. 
